### PR TITLE
Fix already existing cert

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -11093,17 +11093,24 @@ function setupMaven(opts) {
         const p12Path = path.join(certDir, 'certificate.p12');
         fs.writeFileSync(p12Path, Buffer.from(opts.keystore, 'base64'));
         core.exportVariable('MAVEN_OPTS', `-Djavax.net.ssl.keyStore=${p12Path} -Djavax.net.ssl.keyStoreType=pkcs12 -Djavax.net.ssl.keyStorePassword=${opts.password}`);
-        yield exec.exec(path.join(opts.javaPath, 'bin/keytool'), [
-            '-importcert',
-            '-cacerts',
-            '-storepass',
-            'changeit',
-            '-noprompt',
-            '-alias',
-            'mycert',
-            '-file',
-            rooCaPath
-        ]);
+        try {
+            yield exec.exec(path.join(opts.javaPath, 'bin/keytool'), [
+                '-importcert',
+                '-cacerts',
+                '-storepass',
+                'changeit',
+                '-noprompt',
+                '-alias',
+                'mycert',
+                '-file',
+                rooCaPath
+            ]);
+        }
+        catch (e) {
+            if (!e.message.includes('already exists')) {
+                throw e;
+            }
+        }
         core.debug(`added maven opts for MTLS access`);
     });
 }

--- a/src/maven.ts
+++ b/src/maven.ts
@@ -65,17 +65,23 @@ export async function setupMaven(opts: MavenOpts): Promise<void> {
     `-Djavax.net.ssl.keyStore=${p12Path} -Djavax.net.ssl.keyStoreType=pkcs12 -Djavax.net.ssl.keyStorePassword=${opts.password}`
   );
 
-  await exec.exec(path.join(opts.javaPath, 'bin/keytool'), [
-    '-importcert',
-    '-cacerts',
-    '-storepass',
-    'changeit',
-    '-noprompt',
-    '-alias',
-    'mycert',
-    '-file',
-    rooCaPath
-  ]);
+  try {
+    await exec.exec(path.join(opts.javaPath, 'bin/keytool'), [
+      '-importcert',
+      '-cacerts',
+      '-storepass',
+      'changeit',
+      '-noprompt',
+      '-alias',
+      'mycert',
+      '-file',
+      rooCaPath
+    ]);
+  } catch (e) {
+    if (!(e as Error).message.includes('already exists')) {
+      throw e;
+    }
+  }
 
   core.debug(`added maven opts for MTLS access`);
 }


### PR DESCRIPTION
Fix situation of already exsiting cacert in java
trustore. It can happen with cached tooling

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.