### PR TITLE
Add cacert rule for java 8

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Tradeshift/developer-productivity

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -21,7 +21,8 @@ async function run() {
       securitySettings: core.getInput(
         constants.INPUT_MAVEN_SECURITY_SETTINGS_B64
       ),
-      javaPath: ''
+      javaPath: '',
+      javaVersion: version
     };
 
     const mvnVersion = core.getInput(constants.INPUT_MAVEN_VERSION);


### PR DESCRIPTION
We need to add cacert for java truststore 

It is done a little bit different for different Java versions.

This commit adds support of cacert setup for Java 8 