### PR TITLE
fix: check if cert is in keystore

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -11102,15 +11102,27 @@ function setupMaven(opts) {
             params.push('-cacerts');
         }
         try {
-            yield exec.exec(path.join(opts.javaPath, 'bin/keytool'), params.concat([
+            const certexists = yield exec.exec(path.join(opts.javaPath, 'bin/keytool'), [
+                '-list',
                 '-storepass',
                 'changeit',
                 '-noprompt',
                 '-alias',
                 'mycert',
-                '-file',
-                rootCaPath
-            ]));
+                '-keystore',
+                `${opts.javaPath}/jre/lib/security/cacerts`
+            ]);
+            if (certexists !== 0) {
+                yield exec.exec(path.join(opts.javaPath, 'bin/keytool'), params.concat([
+                    '-storepass',
+                    'changeit',
+                    '-noprompt',
+                    '-alias',
+                    'mycert',
+                    '-file',
+                    rootCaPath
+                ]));
+            }
         }
         catch (e) {
             core.warning(`keytool return an error: ${e.message}`);

--- a/src/maven.ts
+++ b/src/maven.ts
@@ -76,18 +76,33 @@ export async function setupMaven(opts: MavenOpts): Promise<void> {
   }
 
   try {
-    await exec.exec(
+    const certexists = await exec.exec(
       path.join(opts.javaPath, 'bin/keytool'),
-      params.concat([
+      [
+        '-list',
         '-storepass',
         'changeit',
         '-noprompt',
         '-alias',
         'mycert',
-        '-file',
-        rootCaPath
-      ])
+        '-keystore',
+        `${opts.javaPath}/jre/lib/security/cacerts`
+      ]
     );
+    if (certexists !== 0) {
+      await exec.exec(
+        path.join(opts.javaPath, 'bin/keytool'),
+        params.concat([
+          '-storepass',
+          'changeit',
+          '-noprompt',
+          '-alias',
+          'mycert',
+          '-file',
+          rootCaPath
+        ])
+      );
+    }
   } catch (e) {
     core.warning(`keytool return an error: ${(e as Error).message}`);
   }


### PR DESCRIPTION
when using the shared cache the cert is already in the keystore

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.