### PR TITLE
fix: Java17 has a different path to the cacerts

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -11102,7 +11102,7 @@ function setupMaven(opts) {
             params.push('-cacerts');
         }
         try {
-            const certexists = yield exec.exec(path.join(opts.javaPath, 'bin/keytool'), [
+            const args = [
                 '-list',
                 '-storepass',
                 'changeit',
@@ -11110,8 +11110,14 @@ function setupMaven(opts) {
                 '-alias',
                 'mycert',
                 '-keystore',
-                `${opts.javaPath}/jre/lib/security/cacerts`
-            ]);
+            ];
+            if (parseInt(opts.javaVersion) >= 17) {
+                args.push(`${opts.javaPath}/lib/security/cacerts`);
+            }
+            else {
+                args.push(`${opts.javaPath}/jre/lib/security/cacerts`);
+            }
+            const certexists = yield exec.exec(path.join(opts.javaPath, 'bin/keytool'), args);
             if (certexists !== 0) {
                 yield exec.exec(path.join(opts.javaPath, 'bin/keytool'), params.concat([
                     '-storepass',

--- a/src/maven.ts
+++ b/src/maven.ts
@@ -76,18 +76,23 @@ export async function setupMaven(opts: MavenOpts): Promise<void> {
   }
 
   try {
+    const args = [
+      '-list',
+      '-storepass',
+      'changeit',
+      '-noprompt',
+      '-alias',
+      'mycert',
+      '-keystore'
+    ];
+    if (parseInt(opts.javaVersion) >= 17) {
+      args.push(`${opts.javaPath}/lib/security/cacerts`);
+    } else {
+      args.push(`${opts.javaPath}/jre/lib/security/cacerts`);
+    }
     const certexists = await exec.exec(
       path.join(opts.javaPath, 'bin/keytool'),
-      [
-        '-list',
-        '-storepass',
-        'changeit',
-        '-noprompt',
-        '-alias',
-        'mycert',
-        '-keystore',
-        `${opts.javaPath}/jre/lib/security/cacerts`
-      ]
+      args
     );
     if (certexists !== 0) {
       await exec.exec(


### PR DESCRIPTION
We assume this change will be the default going forward

See: https://github.com/Tradeshift/document-references-provider/runs/4704847353?check_suite_focus=true#step:5:18

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.