### PR TITLE
fix: the certificate import issue in java 17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ typings/
 # DynamoDB Local files
 .dynamodb/
 .vscode/
+.idea/


### PR DESCRIPTION
**Description:**
The fix for action failing to import root certificate with java version 17

**Related issue:**


**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.